### PR TITLE
[WIP] Re:VIEW用実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-# ascolorbox
+# ascolorbox + Re:VIEW 拡張版
 
-[tcolorboxマニュアル](http://mirrors.ctan.org/macros/latex/contrib/tcolorbox/tcolorbox.pdf)を参考に、新たに作成されたboxです。ascolorboxは主に`\DeclareTColorBox`を用いて定義されているので、引数が豊富です。boxは環境として定義されているので、使い方は通常のtcolorboxに準じます。
+[ascolorbox](https://github.com/Yasunari/ascolorbox) の Re:VIEW 利用向け拡張版です。
+
+- XeLaTeX/pdfLaTeX/LuaLaTeX パッチを適用しています。([オリジナルPR](https://github.com/Yasunari/ascolorbox/pull/2))
+
+以下はオリジナルの README.md の内容です。
+----
+
+# ascolorbox
+[tcolorboxマニュアル](http://mirrors.ctan.org/macros/latex/contrib/tcolorbox/tcolorbox.pdf)を参考に、新たに作成されたboxです。ascolorboxは主に`\DeclareTColorBox`を用いて定義されているので、引数が豊富です。boxは環境として定義されているので、使い方は通常のtcolorboxに準じます。

--- a/ascolorbox.sty
+++ b/ascolorbox.sty
@@ -48,55 +48,60 @@
 % ここからテスト中。こういうパラメータを変換で作って渡したいと思ったんだけど、展開でうまくいかないげ
 \newcommand{\reviewnote@tcoption}{rv line width=5pt,rv line color=red}
 
-% 結局これをパラメータベースで作るなら、tcoptionパラメータも作ってしまえばいい、と言えるか。
+% 結局これをパラメータベースで作らないといけないので、tcoptionパラメータもそのときに付けてしまえばいいか
 \newenvironment{reviewnote}[1][]{%
-  \csdef{review@withcaption}{true}
+  \csdef{rv@withcaption}{true}
   \notblank{#1}{
-%    \begin{rvsimplesquarebox@caption}{#1}[\reviewnote@tcoption]% こちらはだめ。
+%    \begin{rv@simplesquarebox@caption}{#1}[\reviewnote@tcoption]% こちらはだめ。
 % ! Package pgfkeys Error: I do not know the key '/tcb/rv line width=5pt,rv line color=red' and I am going to ignore it. Perhaps you misspelled it.
-    \begin{rvsimplesquarebox@caption}{#1}[rv line width=5pt,rv line color=red]% 直接書けば通る
+    \begin{rv@simplesquarebox@caption}{#1}[rv line width=5pt,rv line color=red]% 直接書けば通る
   }{
-    \csundef{review@withcaption}
-    \begin{rvsimplesquarebox@nocaption}
+    \csundef{rv@withcaption}
+    \begin{rv@simplesquarebox@nocaption}
   }
 }{
-  \ifcsdef{review@withcaption}{
-    \end{rvsimplesquarebox@caption}
+  \ifcsdef{rv@withcaption}{
+    \end{rv@simplesquarebox@caption}
   }{
-    \end{rvsimplesquarebox@nocaption}
+    \end{rv@simplesquarebox@nocaption}
   }
 }
 
+% titleオプションを付ける可能性があることを考えると、Re:VIEW側ではcaption有無でやはり設定分けたほうがよさそう。
 \newenvironment{reviewcaution}[1][]{%
-  \csdef{review@withcaption}{true}
+  \csdef{rv@withcaption}{true}
   \notblank{#1}{
-    \begin{rvsimplesquarebox@caption}{#1}[rv line width=.5pt]
+    \begin{rv@simplesquarebox@caption}{#1}[rv line width=.5pt,title=【#1】]
   }{
-    \csundef{review@withcaption}
-    \begin{rvsimplesquarebox@nocaption}
+    \csundef{rv@withcaption}
+    \begin{rv@simplesquarebox@nocaption}
   }
 }{
-  \ifcsdef{review@withcaption}{
-    \end{rvsimplesquarebox@caption}
+  \ifcsdef{rv@withcaption}{
+    \end{rv@simplesquarebox@caption}
   }{
-    \end{rvsimplesquarebox@nocaption}
+    \end{rv@simplesquarebox@nocaption}
   }
 }
 
-\DeclareTColorBox{rvsimplesquarebox@nocaption}{ O{} }% 
-{}
+\DeclareTColorBox{rv@simplesquarebox@nocaption}{ O{} }% 
+{empty, left=2mm, right=2mm, top=2.5mm, breakable,
+  borderline={\tcb@rv@line@width}{0pt}{\tcb@rv@line@color},
+  arc=0mm,
+  #1}
 
-\DeclareTColorBox{rvsimplesquarebox@caption}{ m O{} }% 
-{empty, left=2mm, right=2mm, top=-1mm, attach boxed title to top left={xshift=\ascb@zw{1.2}{11pt}}, boxed title style={empty,left=-2mm,right=-2mm}, colframe=\tcb@rv@line@color, coltitle=\tcb@rv@line@color, coltext=\tcb@rv@line@color, breakable,
-underlay unbroken={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](title.east) -- (title.east-|frame.east) -- (frame.south east) -- (frame.south west) -- (title.west-|frame.west) -- (title.west); },
-underlay first={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](title.east) -- (title.east-|frame.east) -- (frame.south east) ;
-\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width] (frame.south west) -- (title.west-|frame.west) -- (title.west); },
-underlay middle={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.north east) -- (frame.south east) ;
-\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.south west) -- (frame.north west) ;},
-underlay last={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.north east) -- (frame.south east) -- (frame.south west) -- (frame.north west) ;},
-fonttitle=\ascb@gtfamily, title=【#1】,
+\DeclareTColorBox{rv@simplesquarebox@caption}{ m O{} }% 
+{empty, left=2mm, right=2mm, top=-1mm, attach boxed title to top left={xshift=\ascb@zw{1.2}{11pt}}, boxed title style={empty,left=-2mm,right=-2mm}, colframe=\tcb@rv@line@color, coltitle=\tcb@rv@line@color, coltext=black, breakable,
+  underlay unbroken={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](title.east) -- (title.east-|frame.east) -- (frame.south east) -- (frame.south west) -- (title.west-|frame.west) -- (title.west); },
+  underlay first={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](title.east) -- (title.east-|frame.east) -- (frame.south east) ;
+  \draw[\tcb@rv@line@color,line width=\tcb@rv@line@width] (frame.south west) -- (title.west-|frame.west) -- (title.west); },
+  underlay middle={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.north east) -- (frame.south east) ;
+  \draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.south west) -- (frame.north west) ;},
+  underlay last={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.north east) -- (frame.south east) -- (frame.south west) -- (frame.north west) ;},
+  fonttitle=\ascb@gtfamily, title=【#1】,
 #2}
 
+%% ここから元々のascolorbox
 \DeclareTColorBox{simplesquarebox}{ o m O{.5} O{} }% 
 {empty, left=2mm, right=2mm, top=-1mm, attach boxed title to top left={xshift=\ascb@zw{1.2}{11pt}}, boxed title style={empty,left=-2mm,right=-2mm}, colframe=black, coltitle=black, coltext=black, breakable, 
 underlay unbroken={\draw[black,line width=#3pt](title.east) -- (title.east-|frame.east) -- (frame.south east) -- (frame.south west) -- (title.west-|frame.west) -- (title.west); },

--- a/ascolorbox.sty
+++ b/ascolorbox.sty
@@ -1,5 +1,6 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{ascolorbox}[2019/4/30, Version 1.0.3]
+% original version: 2019/4/30, Version 1.0.3]
 \RequirePackage{tikz,tcolorbox,varwidth,multicol,ifthen,ifptex,ifluatex,ifuptex,ifxetex}
 
 \usetikzlibrary{calc}
@@ -32,9 +33,63 @@
                                    \def\ascb@gtfamily{\gtfamily}
                                    \def\ascb@zw#1#2{#2}
                             }
-                     }
+    
+                 }
               }
 }
+
+\newenvironment{reviewnote}[1][]{%
+  \csdef{review@withcaption}{true}
+  \notblank{#1}{
+    \begin{rvsimplesquarebox@caption}{#1}[rv line width=5pt,rv line color=red]
+  }{
+    \csundef{review@withcaption}
+    \begin{rvsimplesquarebox@nocaption}
+  }
+}{
+  \ifcsdef{review@withcaption}{
+    \end{rvsimplesquarebox@caption}
+  }{
+    \end{rvsimplesquarebox@nocaption}
+  }
+}
+
+\newenvironment{reviewcaution}[1][]{%
+  \csdef{review@withcaption}{true}
+  \notblank{#1}{
+    \begin{rvsimplesquarebox@caption}{#1}[rv line width=.5pt]
+  }{
+    \csundef{review@withcaption}
+    \begin{rvsimplesquarebox@nocaption}
+  }
+}{
+  \ifcsdef{review@withcaption}{
+    \end{rvsimplesquarebox@caption}
+  }{
+    \end{rvsimplesquarebox@nocaption}
+  }
+}
+
+\def\tcb@rv@line@width{.5pt}
+\def\tcb@rv@line@color{black}
+\tcbset{
+  rv line width/.store in=\tcb@rv@line@width,
+  rv line color/.store in=\tcb@rv@line@color
+}
+
+\DeclareTColorBox{rvsimplesquarebox@nocaption}{ O{} }% 
+{}
+
+\DeclareTColorBox{rvsimplesquarebox@caption}{ m O{} }% 
+{empty, left=2mm, right=2mm, top=-1mm, attach boxed title to top left={xshift=\ascb@zw{1.2}{11pt}}, boxed title style={empty,left=-2mm,right=-2mm}, colframe=\tcb@rv@line@color, coltitle=\tcb@rv@line@color, coltext=\tcb@rv@line@color, breakable,
+underlay unbroken={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](title.east) -- (title.east-|frame.east) -- (frame.south east) -- (frame.south west) -- (title.west-|frame.west) -- (title.west); },
+underlay first={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](title.east) -- (title.east-|frame.east) -- (frame.south east) ;
+\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width] (frame.south west) -- (title.west-|frame.west) -- (title.west); },
+underlay middle={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.north east) -- (frame.south east) ;
+\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.south west) -- (frame.north west) ;},
+underlay last={\draw[\tcb@rv@line@color,line width=\tcb@rv@line@width](frame.north east) -- (frame.south east) -- (frame.south west) -- (frame.north west) ;},
+fonttitle=\ascb@gtfamily, title=【#1】,
+#2}
 
 \DeclareTColorBox{simplesquarebox}{ o m O{.5} O{} }% 
 {empty, left=2mm, right=2mm, top=-1mm, attach boxed title to top left={xshift=\ascb@zw{1.2}{11pt}}, boxed title style={empty,left=-2mm,right=-2mm}, colframe=black, coltitle=black, coltext=black, breakable, 
@@ -44,8 +99,9 @@ underlay first={\draw[black,line width=#3pt](title.east) -- (title.east-|frame.e
 underlay middle={\draw[black,line width=#3pt](frame.north east) -- (frame.south east) ;
 \draw[black,line width=#3pt](frame.south west) -- (frame.north west) ;},
 underlay last={\draw[black,line width=#3pt](frame.north east) -- (frame.south east) -- (frame.south west) -- (frame.north west) ;},
-fonttitle=\ascb@gtfamily, IfValueTF={#1}{title=【#2】〈#1〉}{title=【#2】},#4}
-
+fonttitle=\ascb@gtfamily, %
+IfValueTF={#1}{title=【#2】〈#1〉}{title=【#2】},
+#4}
 
 \DeclareTColorBox{practicebox}{ m O{} }%
 {enhanced,sharp corners,colback=black!10!white, colframe=black!10!white , attach boxed title to top left={xshift=0mm,yshift=1mm}, fonttitle=\ascb@gtfamily,varwidth boxed title=0.85\linewidth, breakable, arc=0mm,title={#1},

--- a/ascolorbox.sty
+++ b/ascolorbox.sty
@@ -33,15 +33,28 @@
                                    \def\ascb@gtfamily{\gtfamily}
                                    \def\ascb@zw#1#2{#2}
                             }
-    
                  }
               }
 }
 
+% tcolorboxにパラメータを追加する
+\def\tcb@rv@line@width{.5pt}
+\def\tcb@rv@line@color{black}
+\tcbset{
+  rv line width/.store in=\tcb@rv@line@width,
+  rv line color/.store in=\tcb@rv@line@color
+}
+
+% ここからテスト中。こういうパラメータを変換で作って渡したいと思ったんだけど、展開でうまくいかないげ
+\newcommand{\reviewnote@tcoption}{rv line width=5pt,rv line color=red}
+
+% 結局これをパラメータベースで作るなら、tcoptionパラメータも作ってしまえばいい、と言えるか。
 \newenvironment{reviewnote}[1][]{%
   \csdef{review@withcaption}{true}
   \notblank{#1}{
-    \begin{rvsimplesquarebox@caption}{#1}[rv line width=5pt,rv line color=red]
+%    \begin{rvsimplesquarebox@caption}{#1}[\reviewnote@tcoption]% こちらはだめ。
+% ! Package pgfkeys Error: I do not know the key '/tcb/rv line width=5pt,rv line color=red' and I am going to ignore it. Perhaps you misspelled it.
+    \begin{rvsimplesquarebox@caption}{#1}[rv line width=5pt,rv line color=red]% 直接書けば通る
   }{
     \csundef{review@withcaption}
     \begin{rvsimplesquarebox@nocaption}
@@ -68,13 +81,6 @@
   }{
     \end{rvsimplesquarebox@nocaption}
   }
-}
-
-\def\tcb@rv@line@width{.5pt}
-\def\tcb@rv@line@color{black}
-\tcbset{
-  rv line width/.store in=\tcb@rv@line@width,
-  rv line color/.store in=\tcb@rv@line@color
 }
 
 \DeclareTColorBox{rvsimplesquarebox@nocaption}{ O{} }% 

--- a/ascolorbox.sty
+++ b/ascolorbox.sty
@@ -1,35 +1,66 @@
-\NeedsTeXFormat{pLaTeX2e}
+\NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{ascolorbox}[2019/4/30, Version 1.0.3]
-\RequirePackage{tikz,tcolorbox,varwidth,multicol}
+\RequirePackage{tikz,tcolorbox,varwidth,multicol,ifthen,ifptex,ifluatex,ifuptex,ifxetex}
 
 \usetikzlibrary{calc}
 \tcbuselibrary{xparse,hooks,skins,breakable}
 
+\ifthenelse{\boolean{luatex}}{% LuaLaTeX
+              \RequirePackage{luatexja}
+              \def\ascb@textgt#1{\textgt{#1}}
+              \def\ascb@gtfamily{\gtfamily}
+              \def\ascb@zw#1#2{#1\zw}
+       }{
+              \ifthenelse{\boolean{xetex}}{% XeLaTeX
+                     \RequirePackage{zxjatype}
+                     \def\ascb@textgt#1{\textbf{#1}}
+                     \def\ascb@gtfamily{\bfseries}
+                     \def\ascb@zw#1#2{#2}
+              }{
+                     \ifthenelse{\boolean{ptex}}{% pLaTeX
+                            \def\ascb@textgt#1{\textgt{#1}}
+                            \def\ascb@gtfamily{\gtfamily}
+                            \def\ascb@zw#1#2{#1zw}
+                     }{
+                            \ifthenelse{\boolean{uptex}}{% upLaTeX
+                                   \def\ascb@textgt#1{\textgt{#1}}
+                                   \def\ascb@gtfamily{\gtfamily}
+                                   \def\ascb@zw#1#2{#1zw}
+                            }{% pdfLaTeX
+                                   \RequirePackage[whole]{bxcjkjatype}
+                                   \def\ascb@textgt#1{\textbf{#1}}
+                                   \def\ascb@gtfamily{\gtfamily}
+                                   \def\ascb@zw#1#2{#2}
+                            }
+                     }
+              }
+}
+
 \DeclareTColorBox{simplesquarebox}{ o m O{.5} O{} }% 
-{empty, left=2mm, right=2mm, top=-1mm, attach boxed title to top left={xshift=1.2zw}, boxed title style={empty,left=-2mm,right=-2mm}, colframe=black, coltitle=black, coltext=black, breakable, 
+{empty, left=2mm, right=2mm, top=-1mm, attach boxed title to top left={xshift=\ascb@zw{1.2}{11pt}}, boxed title style={empty,left=-2mm,right=-2mm}, colframe=black, coltitle=black, coltext=black, breakable, 
 underlay unbroken={\draw[black,line width=#3pt](title.east) -- (title.east-|frame.east) -- (frame.south east) -- (frame.south west) -- (title.west-|frame.west) -- (title.west); },
 underlay first={\draw[black,line width=#3pt](title.east) -- (title.east-|frame.east) -- (frame.south east) ;
 \draw[black,line width=#3pt] (frame.south west) -- (title.west-|frame.west) -- (title.west); },
 underlay middle={\draw[black,line width=#3pt](frame.north east) -- (frame.south east) ;
 \draw[black,line width=#3pt](frame.south west) -- (frame.north west) ;},
 underlay last={\draw[black,line width=#3pt](frame.north east) -- (frame.south east) -- (frame.south west) -- (frame.north west) ;},
-fonttitle=\gtfamily, IfValueTF={#1}{title=【#2】〈#1〉}{title=【#2】},#4}
+fonttitle=\ascb@gtfamily, IfValueTF={#1}{title=【#2】〈#1〉}{title=【#2】},#4}
 
 
 \DeclareTColorBox{practicebox}{ m O{} }%
-{enhanced,sharp corners,colback=black!10!white, colframe=black!10!white , attach boxed title to top left={xshift=0mm,yshift=1mm}, fonttitle=\gtfamily,varwidth boxed title=0.85\linewidth, breakable, arc=0mm,title={#1},
+{enhanced,sharp corners,colback=black!10!white, colframe=black!10!white , attach boxed title to top left={xshift=0mm,yshift=1mm}, fonttitle=\ascb@gtfamily,varwidth boxed title=0.85\linewidth, breakable, arc=0mm,title={#1},
 enlarge top by=2mm,
    boxed title style={empty,arc=0pt,outer arc=0pt,boxrule=0pt},
    underlay unbroken and first={
       \draw[black,ultra thick] (frame.north west) -- (frame.north east);
       \draw[black] ([yshift=-.8mm]frame.north west) -- ([yshift=-.8mm]frame.north east);
       \fill[black] ([yshift=1mm]frame.north west) rectangle +(6mm,6mm);
-      \node[white] at ([xshift=3mm,yshift=4mm]frame.north west){\large\textgt{練}};
-      \node at ([xshift=9mm,yshift=4mm]frame.north west){\large\textgt{習}};
+      \node[white] at ([xshift=3mm,yshift=4mm]frame.north west){\large{練}};
+      \node at ([xshift=9mm,yshift=4mm]frame.north west){\large\ascb@textgt{習}};
       \fill[black] ([xshift=12mm,yshift=1mm]frame.north west) rectangle +(6mm,6mm);
-      \node[white] at ([xshift=15mm,yshift=4mm]frame.north west){\large\textgt{問}};
-      \node at ([xshift=21mm,yshift=4mm]frame.north west){\large\textgt{題}};
-      \draw[thick] ([yshift=1mm]frame.north west) -- ++(0mm,6mm) -- ++(24mm,0mm) -- node[right=2mm] {\textgt{#1}} ++(0mm,-6mm) -- cycle;
+      \node[white] at ([xshift=15mm,yshift=4mm]frame.north west){\large\ascb@textgt{問}};
+      \node at ([xshift=21mm,yshift=4mm]frame.north west){\large\ascb@textgt{題}};
+      \draw[thick] ([yshift=1mm]frame.north west) -- ++(0mm,6mm) -- ++(24mm,0mm) -- node[right=2mm] {\ascb@textgt{#1}} ++(0mm,-6mm) -- cycle;
   },
    underlay unbroken and last={
       \draw[black,ultra thick] (frame.south west) -- (frame.south east);
@@ -39,7 +70,7 @@ enlarge top by=2mm,
 
 
 \DeclareTColorBox{ascolorbox1}{ o m O{}}%
-{enhanced,colback=white, skin=enhancedlast jigsaw,breakable, attach boxed title to top left={xshift=-4mm,yshift=-0.5mm}, fonttitle=\bfseries\gtfamily, varwidth boxed title=0.85\linewidth, colbacktitle=black!45!white,colframe=black,
+{enhanced,colback=white, skin=enhancedlast jigsaw,breakable, attach boxed title to top left={xshift=-4mm,yshift=-0.5mm}, fonttitle=\bfseries\ascb@gtfamily, varwidth boxed title=0.85\linewidth, colbacktitle=black!45!white,colframe=black,
    boxed title style={empty,arc=0pt,outer arc=0pt,boxrule=0pt},
    underlay boxed title={%
 \fill[black!45!white] (title.north west) -- (title.north east) -- +(\tcboxedtitleheight-1mm,-\tcboxedtitleheight+1mm)
@@ -98,7 +129,7 @@ underlay last={\draw[#2,line width=1pt]
 
 \DeclareTColorBox{ascolorbox4}{ o m O{3} O{}}%
 {enhanced, colback=white, colframe=white,
-attach boxed title to top left={xshift=1cm,yshift=-\tcboxedtitleheight/2}, fonttitle=\bfseries,varwidth boxed title=0.85\linewidth, coltitle=black, fonttitle=\gtfamily, 
+attach boxed title to top left={xshift=1cm,yshift=-\tcboxedtitleheight/2}, fonttitle=\bfseries,varwidth boxed title=0.85\linewidth, coltitle=black, fonttitle=\ascb@gtfamily, 
 enlarge top by=2mm, enlarge bottom by=2mm, breakable, sharp corners,
 boxed title style={colback=white,left=0mm,right=0mm}, 
 borderline={.75pt}{#3pt}{black,dotted},
@@ -155,11 +186,11 @@ IfValueTF={#1}{title=【#2】〈#1〉}{title=【#2】},#4}
 
 
 \DeclareTColorBox{ascolorbox5}{ O{} m O{black} O{} }%
-{enhanced,colback=white, colframe=white, coltext=#3, attach boxed title to top left={xshift=1mm,yshift=0mm}, fonttitle=\bfseries\gtfamily,varwidth boxed title=0.85\linewidth, colbacktitle=black!45!white, breakable,
+{enhanced,colback=white, colframe=white, coltext=#3, attach boxed title to top left={xshift=1mm,yshift=0mm}, fonttitle=\bfseries\ascb@gtfamily,varwidth boxed title=0.85\linewidth, colbacktitle=black!45!white, breakable,
 enlarge top by=3mm, enlarge bottom by=3mm, 
    boxed title style={empty,arc=0pt,outer arc=0pt,boxrule=0pt},
    underlay boxed title={\fill[#3] (title.north west) 
-      -- (title.north east) --node[right=3mm]{\textgt{#1}}+(0,-\tcboxedtitleheight+.5mm)
+      -- (title.north east) --node[right=3mm]{\ascb@textgt{#1}}+(0,-\tcboxedtitleheight+.5mm)
       -- ([xshift=-1mm,yshift=.5mm]frame.north east) 
       -- +(0mm,-.5mm) -- (title.south west) -- cycle;
       \draw[#3] ([yshift=-.5mm]title.south west) --
@@ -245,7 +276,7 @@ title={#1},#3}
 
 \DeclareTColorBox{ascolorbox10}{ o m O{.8} O{} }%
 {enhanced, interior hidden, colframe=white,
-attach boxed title to top left={xshift=6mm,yshift*=-1.5mm}, fonttitle=\gtfamily, coltitle=black, 
+attach boxed title to top left={xshift=6mm,yshift*=-1.5mm}, fonttitle=\ascb@gtfamily, coltitle=black, 
 , left=1mm, right=1mm,breakable,top=0mm,
 boxed title style={empty,left=-2mm,right=-2mm}, 
 underlay unbroken and first={\draw[black!40!white,line width=1pt, dotted]
@@ -267,7 +298,7 @@ IfValueTF={#1}{title=【#2】〈#1〉}{title=【#2】},#4}
 
 \DeclareTColorBox{ascolorbox11}{ o m O{4} O{} }%
 {enhanced, colback=white, colframe=white,
-attach boxed title to top left={xshift=1cm,yshift=-3mm}, fonttitle=\gtfamily,varwidth boxed title=0.85\linewidth, 
+attach boxed title to top left={xshift=1cm,yshift=-3mm}, fonttitle=\ascb@gtfamily,varwidth boxed title=0.85\linewidth, 
 boxed title style={empty,left=-2mm,right=-2mm}, coltitle=black,breakable,
 underlay unbroken={\draw[gray!40!white,line width=.5pt]
        ([yshift=-#3*0.5pt]title.east)--([yshift=-#3*0.5pt]title.east-|frame.east) -- ++ (0pt,#3pt) -- ++ (-#3pt,0pt)
@@ -468,7 +499,7 @@ title={#2},#1}
 \newenvironment{ascolorbox15}[2][]{%
 \begin{ascolorbox@originalascolorbox15}[#1]{#2}%
 \setlength{\columnseprule}{0pt}%
-\columnsep=5.5zw
+\columnsep=\ascb@zw{5.5}{51pt}
 \begin{multicols}{2}%
 }{%
 \end{multicols}%
@@ -491,7 +522,7 @@ IfValueTF={#1}{title={#2〈#1〉}}{title=#2},#3}
 
 \DeclareTColorBox{ascolorbox17}{ o m O{gray} O{}}%
 {enhanced, colback=white, colframe=white,
-attach boxed title to top left={xshift=1.5cm,yshift=-\tcboxedtitleheight/2}, fonttitle=\bfseries,varwidth boxed title=0.85\linewidth, coltitle=black, fonttitle=\gtfamily, 
+attach boxed title to top left={xshift=1.5cm,yshift=-\tcboxedtitleheight/2}, fonttitle=\bfseries,varwidth boxed title=0.85\linewidth, coltitle=black, fonttitle=\ascb@gtfamily, 
 enlarge top by=2mm, enlarge bottom by=2mm, breakable,
 boxed title style={colback=white,left=0mm,right=0mm},
 underlay unbroken={\draw[fill=black, draw=black]
@@ -528,7 +559,7 @@ cos +(\tcboxedtitleheight,\tcboxedtitleheight/2) sin +(\tcboxedtitleheight,\tcbo
 
 \DeclareTColorBox{ascolorbox19}{ o m O{2} O{}}%
 {enhanced, colback=white, colframe=white,
-attach boxed title to top left={xshift=5mm,yshift=-\tcboxedtitleheight/2}, fonttitle=\bfseries,varwidth boxed title=0.85\linewidth, coltitle=black, fonttitle=\gtfamily, 
+attach boxed title to top left={xshift=5mm,yshift=-\tcboxedtitleheight/2}, fonttitle=\bfseries,varwidth boxed title=0.85\linewidth, coltitle=black, fonttitle=\ascb@gtfamily, 
 enlarge top by=2mm, enlarge bottom by=2mm, breakable, top=3mm, bottom=3mm,
 boxed title style={colback=white,left=0mm,right=0mm,top=-1mm,bottom=-1mm}, 
 underlay unbroken={\draw[black!40!white,line width=.5pt]

--- a/test/common.tex
+++ b/test/common.tex
@@ -1,0 +1,328 @@
+% Re:VIEWの場合サブタイトルは使わない前提
+% ---------------------------------------------
+\begin{simplesquarebox}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{simplesquarebox}
+
+% FIXME:キャプションなしの表現がおかしい
+\begin{simplesquarebox}{}
+
+TEST, TEST, TEST
+
+\end{simplesquarebox}
+
+% オプションとしてthicknessを持つ
+\begin{simplesquarebox}{CAPTION}[1.5]
+
+TEST, TEST, TEST
+
+\end{simplesquarebox}
+
+% ---------------------------------------------
+% FIXME:1行の内容のときにおかしい
+\begin{practicebox}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{practicebox}
+
+\begin{practicebox}{}
+
+TEST, TEST, TEST
+
+\end{practicebox}
+
+% ---------------------------------------------
+\begin{ascolorbox1}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox1}
+
+% FIXME:キャプションなしのときにおかしい
+\begin{ascolorbox1}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox1}
+
+% ---------------------------------------------
+\begin{ascolorbox2}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox2}
+
+\begin{ascolorbox2}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox2}
+
+% ---------------------------------------------
+\begin{ascolorbox3}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox3}
+
+% FIXME:キャプションなしのときにちょっとおかしい
+\begin{ascolorbox3}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox3}
+
+% オプションとして枠色を持つ
+\begin{ascolorbox3}{CAPTION}[orange]
+
+TEST, TEST, TEST
+
+\end{ascolorbox3}
+
+% ---------------------------------------------
+\begin{ascolorbox4}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox4}
+
+% FIXME:キャプションなしのときにおかしい
+\begin{ascolorbox4}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox4}
+
+% オプションとして幅・半径を持つ
+\begin{ascolorbox4}{CAPTION}[2]
+
+TEST, TEST, TEST
+
+\end{ascolorbox4}
+
+% ---------------------------------------------
+\begin{ascolorbox5}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox5}
+
+% FIXME:キャプションなしのときにエラー
+%\begin{ascolorbox5}{ }
+
+%TEST, TEST, TEST
+
+%\end{ascolorbox5}
+
+% 色を変える
+\begin{ascolorbox5}{CAPTION}[orange]
+
+TEST, TEST, TEST
+
+\end{ascolorbox5}
+
+% ---------------------------------------------
+\begin{ascolorbox8}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox8}
+
+\begin{ascolorbox8}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox8}
+
+% ---------------------------------------------
+\begin{ascolorbox9}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox9}
+
+% FIXME:キャプションなしのときにエラー
+%\begin{ascolorbox9}{}
+
+%TEST, TEST, TEST
+
+%\end{ascolorbox9}
+
+% 丸模様の繰り返し回数
+\begin{ascolorbox9}{CAPTION}[5]
+
+TEST, TEST, TEST
+
+\end{ascolorbox9}
+
+% ---------------------------------------------
+\begin{ascolorbox10}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox10}
+
+% FIXME:キャプションなしの表現がおかしい
+\begin{ascolorbox10}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox10}
+
+% オプションとしてthicknessを持つ
+\begin{ascolorbox10}{CAPTION}[1.5]
+
+TEST, TEST, TEST
+
+\end{ascolorbox10}
+
+% ---------------------------------------------
+\begin{ascolorbox11}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox11}
+
+% FIXME:キャプションなしの表現がおかしい
+\begin{ascolorbox11}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox11}
+
+% オプションとして半径を持つ
+\begin{ascolorbox11}{CAPTION}[2]
+
+TEST, TEST, TEST
+
+\end{ascolorbox11}
+
+% ---------------------------------------------
+\begin{ascolorbox12}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox12}
+
+% FIXME:キャプションなしの表現がちょっとおかしい
+\begin{ascolorbox12}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox12}
+
+% ---------------------------------------------
+\begin{ascolorbox13}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox13}
+
+\begin{ascolorbox13}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox13}
+
+% ---------------------------------------------
+\begin{ascolorbox14}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox14}
+
+% FIXME:キャプションなしの表現がちょっとおかしい
+\begin{ascolorbox14}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox14}
+
+% ---------------------------------------------
+\begin{ascolorbox15}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox15}
+
+% FIXME:キャプションなしの表現がちょっとおかしい
+\begin{ascolorbox15}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox15}
+
+% ---------------------------------------------
+\begin{ascolorbox16}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox16}
+
+% FIXME:キャプションなしの表現がおかしい
+\begin{ascolorbox16}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox16}
+
+% ---------------------------------------------
+\begin{ascolorbox17}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox17}
+
+% FIXME:キャプションなしの表現がおかしい
+\begin{ascolorbox17}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox17}
+
+% オプションとして枠色変更を持つ
+\begin{ascolorbox17}{CAPTION}[orange]
+
+TEST, TEST, TEST
+
+\end{ascolorbox17}
+
+% ---------------------------------------------
+\begin{ascolorbox18}{CAPTION}
+
+TEST, TEST, TEST
+
+\end{ascolorbox18}
+
+\begin{ascolorbox18}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox18}
+
+\begin{ascolorbox19}{CAPTION}
+
+TEST, TEST, TEST
+
+% ---------------------------------------------
+\end{ascolorbox19}
+
+% FIXME:キャプションなしの表現がおかしい
+\begin{ascolorbox19}{}
+
+TEST, TEST, TEST
+
+\end{ascolorbox19}
+
+% オプションとして間隔を持つ
+\begin{ascolorbox19}{CAPTION}[5]
+
+TEST, TEST, TEST
+
+\end{ascolorbox19}
+
+% 普通にシンプルなもの、二重囲み程度のものも追加で用意する
+% ascboxを見出しに付ける方法もほしくなりそう

--- a/test/common.tex
+++ b/test/common.tex
@@ -1,5 +1,7 @@
 % Re:VIEWの場合サブタイトルは使わない前提
 % ---------------------------------------------
+simplesquarebox
+
 \begin{simplesquarebox}{CAPTION}
 
 TEST, TEST, TEST
@@ -13,6 +15,7 @@ TEST, TEST, TEST
 
 \end{simplesquarebox}
 
+
 % オプションとしてthicknessを持つ
 \begin{simplesquarebox}{CAPTION}[1.5]
 
@@ -20,7 +23,54 @@ TEST, TEST, TEST
 
 \end{simplesquarebox}
 
+% review側からは\begin{note}[CAPTION] になる。
+
+% オプションでやりづらい… CAPTION、固有オプション、tcolorboxオプション で指定できるものとする。
+
+\begin{reviewnote}
+
+TEST, TEST, TEST
+
+\end{reviewnote}
+
+\begin{reviewnote}[CAPTION]
+
+TEST, TEST, TEST
+
+\end{reviewnote}
+
+\begin{reviewcaution}[CAPTION]
+
+TEST, TEST, TEST
+
+\end{reviewcaution}
+
+\begin{reviewnote}[CAPTION]
+
+TEST, TEST, TEST
+
+\end{reviewnote}
+
+% \begin{rvsimplesquarebox}{CAPTION}{thickness=1.5}{colframe=red!75!black}
+% 
+% TEST, TEST, TEST
+% 
+% \end{rvsimplesquarebox}
+% 
+% \begin{rvsimplesquarebox}{}{thickness=1.5}{}
+% 
+% TEST, TEST, TEST
+% 
+% \end{rvsimplesquarebox}
+% 
+% \begin{rvsimplesquarebox}{}{}{}
+% 
+% TEST, TEST, TEST
+% 
+% \end{rvsimplesquarebox}
+
 % ---------------------------------------------
+practicebox
 % FIXME:1行の内容のときにおかしい
 \begin{practicebox}{CAPTION}
 
@@ -35,6 +85,8 @@ TEST, TEST, TEST
 \end{practicebox}
 
 % ---------------------------------------------
+ascolorbox1
+
 \begin{ascolorbox1}{CAPTION}
 
 TEST, TEST, TEST
@@ -49,6 +101,8 @@ TEST, TEST, TEST
 \end{ascolorbox1}
 
 % ---------------------------------------------
+ascolorbox2
+
 \begin{ascolorbox2}{CAPTION}
 
 TEST, TEST, TEST
@@ -62,6 +116,8 @@ TEST, TEST, TEST
 \end{ascolorbox2}
 
 % ---------------------------------------------
+ascolorbox3
+
 \begin{ascolorbox3}{CAPTION}
 
 TEST, TEST, TEST
@@ -83,6 +139,8 @@ TEST, TEST, TEST
 \end{ascolorbox3}
 
 % ---------------------------------------------
+ascolorbox4
+
 \begin{ascolorbox4}{CAPTION}
 
 TEST, TEST, TEST
@@ -104,6 +162,8 @@ TEST, TEST, TEST
 \end{ascolorbox4}
 
 % ---------------------------------------------
+ascolorbox5
+
 \begin{ascolorbox5}{CAPTION}
 
 TEST, TEST, TEST
@@ -125,6 +185,8 @@ TEST, TEST, TEST
 \end{ascolorbox5}
 
 % ---------------------------------------------
+ascolorbox8
+
 \begin{ascolorbox8}{CAPTION}
 
 TEST, TEST, TEST
@@ -138,6 +200,8 @@ TEST, TEST, TEST
 \end{ascolorbox8}
 
 % ---------------------------------------------
+ascolorbox9
+
 \begin{ascolorbox9}{CAPTION}
 
 TEST, TEST, TEST
@@ -159,6 +223,8 @@ TEST, TEST, TEST
 \end{ascolorbox9}
 
 % ---------------------------------------------
+ascolorbox10
+
 \begin{ascolorbox10}{CAPTION}
 
 TEST, TEST, TEST
@@ -180,6 +246,8 @@ TEST, TEST, TEST
 \end{ascolorbox10}
 
 % ---------------------------------------------
+ascolorbox11
+
 \begin{ascolorbox11}{CAPTION}
 
 TEST, TEST, TEST
@@ -201,6 +269,8 @@ TEST, TEST, TEST
 \end{ascolorbox11}
 
 % ---------------------------------------------
+ascolorbox12
+
 \begin{ascolorbox12}{CAPTION}
 
 TEST, TEST, TEST
@@ -215,6 +285,8 @@ TEST, TEST, TEST
 \end{ascolorbox12}
 
 % ---------------------------------------------
+ascolorbox13
+
 \begin{ascolorbox13}{CAPTION}
 
 TEST, TEST, TEST
@@ -228,6 +300,8 @@ TEST, TEST, TEST
 \end{ascolorbox13}
 
 % ---------------------------------------------
+ascolorbox14
+
 \begin{ascolorbox14}{CAPTION}
 
 TEST, TEST, TEST
@@ -242,6 +316,8 @@ TEST, TEST, TEST
 \end{ascolorbox14}
 
 % ---------------------------------------------
+ascolorbox15
+
 \begin{ascolorbox15}{CAPTION}
 
 TEST, TEST, TEST
@@ -256,6 +332,8 @@ TEST, TEST, TEST
 \end{ascolorbox15}
 
 % ---------------------------------------------
+ascolorbox16
+
 \begin{ascolorbox16}{CAPTION}
 
 TEST, TEST, TEST
@@ -270,6 +348,8 @@ TEST, TEST, TEST
 \end{ascolorbox16}
 
 % ---------------------------------------------
+ascolorbox17
+
 \begin{ascolorbox17}{CAPTION}
 
 TEST, TEST, TEST
@@ -291,6 +371,8 @@ TEST, TEST, TEST
 \end{ascolorbox17}
 
 % ---------------------------------------------
+ascolorbox18
+
 \begin{ascolorbox18}{CAPTION}
 
 TEST, TEST, TEST
@@ -308,6 +390,8 @@ TEST, TEST, TEST
 TEST, TEST, TEST
 
 % ---------------------------------------------
+ascolorbox19
+
 \end{ascolorbox19}
 
 % FIXME:キャプションなしの表現がおかしい

--- a/test/test-luatex.tex
+++ b/test/test-luatex.tex
@@ -1,0 +1,5 @@
+\documentclass{ltjsarticle}
+\usepackage{../ascolorbox}
+\begin{document}
+\input{common}
+\end{document}

--- a/test/test-uptex.tex
+++ b/test/test-uptex.tex
@@ -1,0 +1,8 @@
+% upLaTeXテスト
+\documentclass[uplatex,dvipdfmx]{jsarticle}
+\usepackage{../ascolorbox}
+\begin{document}
+
+\input{common}
+
+\end{document}


### PR DESCRIPTION
- サブキャプションはRe:VIEWにないので使わない
- `rv@装飾名@caption`と`rv@装飾名@nocaption`の2つを作り、これをreviewnoteやreviewcautionなどがキャプション有無で判断して呼び出すようにする。
- オプションパラメータはtcbsetでrv 〜のオプションを追加するようにする(空白OK)。パラメータ値実体はtcb@rv@〜に。

reviewnoteなどの内容はパラメータから自動生成させるとして、設定YAML側をどう書くか。